### PR TITLE
Clear Input Trigger After Perform Click after Frame

### DIFF
--- a/papa/src/main/java/papa/internal/InputTracker.kt
+++ b/papa/src/main/java/papa/internal/InputTracker.kt
@@ -16,6 +16,7 @@ import curtains.keyEventInterceptors
 import curtains.phoneWindow
 import curtains.touchEventInterceptors
 import curtains.windowAttachCount
+import papa.Choreographers
 import papa.InputEventTrigger
 import papa.InteractionTriggerWithPayload
 import papa.MainThreadTriggerStack
@@ -92,8 +93,12 @@ internal object InputTracker {
           // we're clearing the event right after the onclick is handled.
           if (isActionUp) {
             val clearEventForPostedClick = Runnable {
-              actionUpTrigger!!.takeOverInteractionTrace()?.endTrace()
-              MainThreadTriggerStack.popTriggeredBy(actionUpTrigger)
+              Choreographers.postOnFrameRendered {
+                // Take over and clear this if it has not already been taken over by the time of the
+                // frame after the click handling.
+                actionUpTrigger!!.takeOverInteractionTrace()?.endTrace()
+                MainThreadTriggerStack.popTriggeredBy(actionUpTrigger)
+              }
             }
 
             val dispatchEnd = SystemClock.uptimeMillis()


### PR DESCRIPTION
If our input handling does not happen all in one main thread message then the clear callback for the "Tap Interaction" trigger could get removed before we have a chance to take it over by something meaningful.

Rather than moving it immediately after `performClick` and assuming everything is synchronous, remove it after the first frame after `performClick`.